### PR TITLE
Add FindCbc.cmake

### DIFF
--- a/Modules/FindCbc.cmake
+++ b/Modules/FindCbc.cmake
@@ -5,36 +5,16 @@
 #  Cbc_INCLUDE_DIRS - the Cbc include directories
 #  Cbc_LIBRARIES - link these to use Cbc libraries
 
-find_path(Cbc_INCLUDE_DIR
-  NAMES coin/CbcConfig.h
-  )
+find_package(PkgConfig)
+pkg_check_modules(Cbc_PKGCONF QUIET cbc)
 
-find_library(Osi_LIBRARY
-  NAMES Osi
-  )
-
-find_library(CoinUtils_LIBRARY
-  NAMES CoinUtils
-  )
-
-find_library(OsiClp_LIBRARY
-  NAMES OsiClp
-  )
-
-find_library(Cbc_LIBRARY
-  NAMES Cbc
-  )
-
-find_library(Cgl_LIBRARY
-  NAMES Cgl
-  )
-
-set(Cbc_INCLUDE_DIRS ${Cbc_INCLUDE_DIR})
-set(Cbc_LIBRARIES ${Osi_LIBRARY} ${CoinUtils_LIBRARY} ${Cbc_LIBRARY} ${OsiClp_LIBRARY} ${Cgl_LIBRARY})
+set(Cbc_INCLUDE_DIRS ${Cbc_PKGCONF_INCLUDE_DIRS})
+set(Cbc_LIBRARIES ${Cbc_PKGCONF_LIBRARIES})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Cbc; DEFAULT_MSG
+find_package_handle_standard_args(Cbc
+  FOUND_VAR Cbc_FOUND
+  REQUIRED_VARS
   Cbc_LIBRARIES
   Cbc_INCLUDE_DIRS)
 mark_as_advanced(Cbc_INCLUDE_DIRS Cbc_LIBRARIES)
-

--- a/Modules/FindCbc.cmake
+++ b/Modules/FindCbc.cmake
@@ -32,4 +32,5 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Cbc; DEFAULT_MSG
   Cbc_LIBRARIES
   Cbc_INCLUDE_DIRS)
-mark_as_advanced(CBC_INCLUDE_DIRS CBC_LIBRARIES)
+mark_as_advanced(Cbc_INCLUDE_DIRS Cbc_LIBRARIES)
+

--- a/Modules/FindCbc.cmake
+++ b/Modules/FindCbc.cmake
@@ -1,35 +1,35 @@
 # Try to find Cbc (https://projects.coin-or.org/Cbc)
 # Once done, this will define
 #
-#  CBC_FOUND - system has Cbc library
-#  CBC_INCLUDE_DIRS - the Cbc include directories
-#  CBC_LIBRARIES - link these to use Cbc library
+#  Cbc_FOUND - system has Cbc libraries
+#  Cbc_INCLUDE_DIRS - the Cbc include directories
+#  Cbc_LIBRARIES - link these to use Cbc libraries
 
-find_path(CBC_INCLUDE_DIR
+find_path(Cbc_INCLUDE_DIR
   NAMES coin/CbcConfig.h
   )
 
-find_library(OSI_LIBRARY
+find_library(Osi_LIBRARY
   NAMES Osi
   )
 
-find_library(COINUTILS_LIBRARY
+find_library(CoinUtils_LIBRARY
   NAMES CoinUtils
   )
 
-find_library(OSICLP_LIBRARY
+find_library(OsiClp_LIBRARY
   NAMES OsiClp
   )
 
-find_library(CBC_LIBRARY
+find_library(Cbc_LIBRARY
   NAMES Cbc
   )
 
-set(CBC_INCLUDE_DIRS ${CBC_INCLUDE_DIR})
-set(CBC_LIBRARIES ${OSI_LIBRARY} ${COINUTILS_LIBRARY} ${CBC_LIBRARY} ${OSICLP_LIBRARY})
+set(Cbc_INCLUDE_DIRS ${Cbc_INCLUDE_DIR})
+set(Cbc_LIBRARIES ${Osi_LIBRARY} ${CoinUtils_LIBRARY} ${Cbc_LIBRARY} ${OsiClp_LIBRARY})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Cbc; DEFAULT_MSG
-  CBC_LIBRARIES
-  CBC_INCLUDE_DIRS)
+  Cbc_LIBRARIES
+  Cbc_INCLUDE_DIRS)
 mark_as_advanced(CBC_INCLUDE_DIRS CBC_LIBRARIES)

--- a/Modules/FindCbc.cmake
+++ b/Modules/FindCbc.cmake
@@ -9,16 +9,24 @@ find_path(CBC_INCLUDE_DIR
   NAMES coin/CbcConfig.h
   )
 
-find_library(CBC_LIBRARY
-  NAMES Cbc
+find_library(OSI_LIBRARY
+  NAMES Osi
+  )
+
+find_library(COINUTILS_LIBRARY
+  NAMES CoinUtils
   )
 
 find_library(OSICLP_LIBRARY
   NAMES OsiClp
   )
 
+find_library(CBC_LIBRARY
+  NAMES Cbc
+  )
+
 set(CBC_INCLUDE_DIRS ${CBC_INCLUDE_DIR})
-set(CBC_LIBRARIES ${CBC_LIBRARY} ${OSICLP_LIBRARY})
+set(CBC_LIBRARIES ${OSI_LIBRARY} ${COINUTILS_LIBRARY} ${CBC_LIBRARY} ${OSICLP_LIBRARY})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Cbc; DEFAULT_MSG

--- a/Modules/FindCbc.cmake
+++ b/Modules/FindCbc.cmake
@@ -1,0 +1,27 @@
+# Try to find Cbc (https://projects.coin-or.org/Cbc)
+# Once done, this will define
+#
+#  CBC_FOUND - system has Cbc library
+#  CBC_INCLUDE_DIRS - the Cbc include directories
+#  CBC_LIBRARIES - link these to use Cbc library
+
+find_path(CBC_INCLUDE_DIR
+  NAMES coin/CbcConfig.h
+  )
+
+find_library(CBC_LIBRARY
+  NAMES Cbc
+  )
+
+find_library(OSICLP_LIBRARY
+  NAMES OsiClp
+  )
+
+set(CBC_INCLUDE_DIRS ${CBC_INCLUDE_DIR})
+set(CBC_LIBRARIES ${CBC_LIBRARY} ${OSICLP_LIBRARY})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Cbc; DEFAULT_MSG
+  CBC_LIBRARIES
+  CBC_INCLUDE_DIRS)
+mark_as_advanced(CBC_INCLUDE_DIRS CBC_LIBRARIES)

--- a/Modules/FindCbc.cmake
+++ b/Modules/FindCbc.cmake
@@ -25,8 +25,12 @@ find_library(Cbc_LIBRARY
   NAMES Cbc
   )
 
+find_library(Cgl_LIBRARY
+  NAMES Cgl
+  )
+
 set(Cbc_INCLUDE_DIRS ${Cbc_INCLUDE_DIR})
-set(Cbc_LIBRARIES ${Osi_LIBRARY} ${CoinUtils_LIBRARY} ${Cbc_LIBRARY} ${OsiClp_LIBRARY})
+set(Cbc_LIBRARIES ${Osi_LIBRARY} ${CoinUtils_LIBRARY} ${Cbc_LIBRARY} ${OsiClp_LIBRARY} ${Cgl_LIBRARY})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Cbc; DEFAULT_MSG


### PR DESCRIPTION
Adding `FindCbc.cmake` that finds all libraries related to solving ILP.