### PR TITLE
ENH: switchable EXCLUDE_FROM_ALL

### DIFF
--- a/buildsys.cmake
+++ b/buildsys.cmake
@@ -402,6 +402,7 @@ foreach(submodule
     symlink-fixes
     tensorflow
     torch
+    exclude-from-all
 
     build-types/release
     build-types/customerdebug

--- a/macros/exclude-from-all.cmake
+++ b/macros/exclude-from-all.cmake
@@ -20,3 +20,5 @@ macro(exclude_from_all TARGET)
   endif()
 endmacro()
 
+setup_exclude_from_all()
+

--- a/macros/exclude-from-all.cmake
+++ b/macros/exclude-from-all.cmake
@@ -1,0 +1,22 @@
+set(_BUILDSYS_EXCLUDE_FROM_ALL TRUE)
+
+macro(setup_exclude_from_all)
+  if(NOT DEFINED BUILDSYS_EXCLUDE_FROM_ALL OR BUILDSYS_EXCLUDE_FROM_ALL)
+    set(_BUILDSYS_EXCLUDE_FROM_ALL TRUE)
+    message(STATUS "Targets marked by exclude_from_all(TARGET) will be excluded from target 'all'")
+  else()
+    set(_BUILDSYS_EXCLUDE_FROM_ALL FALSE)
+    message(STATUS "Targets marked by exclude_from_all(TARGET) will be included from target 'all'")
+  endif()
+endmacro()
+
+macro(exclude_from_all TARGET)
+  if(_BUILDSYS_EXCLUDE_FROM_ALL)
+    message(STATUS "Excluding ${TARGET} from target 'all'.")
+    set_target_properties(${TARGET} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+  else()
+    message(STATUS "Including ${TARGET} in target 'all'.")
+    set_target_properties(${TARGET} PROPERTIES EXCLUDE_FROM_ALL FALSE) 
+  endif()
+endmacro()
+


### PR DESCRIPTION
Added variable `BUILDSYS_EXCLUDE_FROM_ALL` and macro `exclude_from_all(TARGET)`. The macro decorates `TARGET` with `EXCLUDE_FROM_ALL` iff `BUILDSYS_EXCLUDE_FROM_ALL` is not defined or evaluates as `TRUE`. Otherwise, the property `EXCLUDE_FROM_ALL` is dropped. 

The main aim is to allow automatised compilation of targets excluded from a standard build in e.g. a CI/CD pipeline.