### PR TITLE
FindGeographicLib: using alternative name for Debian/Bookworm

### DIFF
--- a/Modules/FindGeographicLib.cmake
+++ b/Modules/FindGeographicLib.cmake
@@ -11,7 +11,7 @@ find_path(GeographicLib_INCLUDE_DIR
 
 # Finally the library itself
 find_library(GeographicLib_LIBRARY
-  NAMES Geographic
+    NAMES Geographic GeographicLib
 )
 
 set(GeographicLib_LIBRARIES ${GeographicLib_LIBRARY})


### PR DESCRIPTION
up to `bullseye`:
`/usr/lib/x86_64-linux-gnu/libGeographic.so`

`bookwrorm`:
`/usr/lib/x86_64-linux-gnu/libGeographicLib.so`
