### PR TITLE
Add long paths support for Windows

### DIFF
--- a/macros/buildsys.windows.cmake
+++ b/macros/buildsys.windows.cmake
@@ -12,6 +12,12 @@ macro(setup_build_system_os_specific)
   add_definitions(-D_USE_MATH_DEFINES)
   add_definitions(-D_ENABLE_EXTENDED_ALIGNED_STORAGE)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+
+  # use manifest file
+  add_link_options(
+    "LINKER:/MANIFEST:EMBED" 
+    "LINKER:/MANIFESTINPUT:${BUILDSYS_ROOT}/manifest/windows.manifest"
+  )
 endmacro()
 
 set(BUILDSYS_SYMLINKS_FIX_SCRIPT

--- a/manifest/windows.manifest
+++ b/manifest/windows.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:compatibility.v1">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
Windows long path support requires:
1) At least `Windows 10, version 1607`
2) [Enabled long paths in Windows registry](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#enable-long-paths-in-windows-10-version-1607-and-later):
`New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force`