### PR TITLE
Updated DEB_PACKAGE_DEBUG behaviour

### DIFF
--- a/include/debian.mk
+++ b/include/debian.mk
@@ -70,7 +70,10 @@ override_dh_auto_configure:
 ifeq ($(DEB_PACKAGE_DEBUG),AUTOMATIC)
 override_dh_strip:
 	dh_strip --automatic-dbgsym
-else ifneq ($(DEB_PACKAGE_DEBUG),NO)
+else ifeq ($(DEB_PACKAGE_DEBUG),NO)
+override_dh_strip:
+	dh_strip --no-automatic-dbgsym
+else
 override_dh_strip:
 	dh_strip --dbg-package=$(DEB_PACKAGE_DEBUG)
 endif


### PR DESCRIPTION
`DEB_PACKAGE_DEBUG` behaviour:
 * `AUTOMATIC`: use `dh_strip --automatic-dbgsym`
 * `NO`: use `dh_strip --no-automatic-dbgsym` **this pull request's change**
 * any other value: `dh_strip --dbg-package=$(DEB_PACKAGE_DEBUG)`

When unset, `DEB_PACKAGE_DEBUG` is set to to `$(DEB_SOURCE)-dbg`.
