### PR TITLE
Vasek/module target name

### DIFF
--- a/buildsys.cmake
+++ b/buildsys.cmake
@@ -7,10 +7,11 @@ endif()
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 
 # buildsystem as a dependency: fake dependency (e.g. BuildSystem>=1.0)
-set(BuildSystem_VERSION 1.14)
+set(BuildSystem_VERSION 1.15)
 set(BuildSystem_FOUND TRUE)
 set(BuildSystem_LIBRARIES)
 set(BuildSystem_DEFINITION)
+set(BuildSystem_TARGETS)
 
 # remember buildsystem root
 set(BUILDSYS_ROOT ${CMAKE_CURRENT_LIST_DIR})

--- a/macros/module.cmake
+++ b/macros/module.cmake
@@ -123,8 +123,10 @@ macro(define_module MODULE_TYPE MODULE_NAME_VERSION DEPENDS)
   unset(definitions)
   unset(module_breaks)
   unset(broken)
+  unset(provided_targets)
+  set(has_provided_targets FALSE)
 
-  set(supported_modes "DEPENDS;DEFINITIONS;BREAKS")
+  set(supported_modes "DEPENDS;DEFINITIONS;BREAKS;PROVIDES")
   set(mode "DEPENDS")
 
   foreach(atom ${ARGN})
@@ -155,7 +157,7 @@ macro(define_module MODULE_TYPE MODULE_NAME_VERSION DEPENDS)
             LIST(APPEND missing ${fullAtom})
           else()
             # add dependency to our libraries
-            list(APPEND libs ${atom})
+            list(APPEND libs ${MODULE_${atom}_TARGETS})
             # add dependency's definitions to our definitions
             list(APPEND definitions ${MODULE_${atom}_DEFINITIONS})
           endif()
@@ -187,6 +189,10 @@ macro(define_module MODULE_TYPE MODULE_NAME_VERSION DEPENDS)
       list(APPEND module_breaks "${breaks_version}")
       list(APPEND module_breaks "${breaks_what}")
       
+    elseif(mode STREQUAL "PROVIDES")
+      # add given name to to provided targets
+      list(APPEND provided_targets ${atom})
+      set(has_provided_targets TRUE)
     else()
       message(FATAL_ERROR "${MODULE_NAME}: INTERNAL ERROR unsupported mode ${mode}")
     endif()
@@ -213,6 +219,15 @@ macro(define_module MODULE_TYPE MODULE_NAME_VERSION DEPENDS)
   if(definitions)
     list(REMOVE_DUPLICATES definitions)
   endif()
+
+  if(NOT has_provided_targets)
+    list(APPEND provided_targets ${MODULE_NAME})
+  endif()
+
+  # set TARGETS
+  set(MODULE_TARGETS ${libs})
+  set(MODULE_${MODULE_NAME}_TARGETS ${provided_targets})
+  set(MODULE_${MODULE_NAME}_TARGETS ${provided_targets} PARENT_SCOPE)
 
   # set LIBRARIES
   set(MODULE_LIBRARIES ${libs})

--- a/macros/module.cmake
+++ b/macros/module.cmake
@@ -139,7 +139,10 @@ macro(define_module MODULE_TYPE MODULE_NAME_VERSION DEPENDS)
       module_split_version(${atom} atom compareOperator version)
 
       # dependency
-      if (NOT ${atom}_FOUND)
+      if (MODULE_${atom}_FOUND # module "atom"
+          OR (TARGET ${atom}  # target "atom" without "atom"_FOUND
+            AND NOT ${atom}_FOUND)
+          )
         if(NOT MODULE_${atom}_FOUND)
           if(TARGET ${atom})
             list(APPEND libs ${atom})
@@ -163,20 +166,21 @@ macro(define_module MODULE_TYPE MODULE_NAME_VERSION DEPENDS)
           endif()
         endif()
       else()
-          module_check_version("${${atom}_VERSION}" "${compareOperator}" "${version}"
-            checkResult)
+        # old "atom"_FOUND
+        module_check_version("${${atom}_VERSION}" "${compareOperator}" "${version}"
+          checkResult)
 
-          if(NOT checkResult)
-            LIST(APPEND missing ${fullAtom})
-          else()
-            # add dependency's libraries to our libraries
-            list(APPEND libs ${${atom}_LIBRARIES})
-            # TODO: split -DX to _DEFINITIONS and other stuff to _FLAGS
-            # do nothing now
+        if(NOT checkResult)
+          LIST(APPEND missing ${fullAtom})
+        else()
+          # add dependency's libraries to our libraries
+          list(APPEND libs ${${atom}_LIBRARIES})
+          # TODO: split -DX to _DEFINITIONS and other stuff to _FLAGS
+          # do nothing now
 
-            # add dependency's definitions to our definitions
-            # list(APPEND definitions ${${atom}_DEFINITIONS})
-          endif()
+          # add dependency's definitions to our definitions
+          # list(APPEND definitions ${${atom}_DEFINITIONS})
+        endif()
       endif()
 
     elseif(mode STREQUAL "DEFINITIONS")


### PR DESCRIPTION
* Module provided variable MODULE_xxx_TARGETS with provided targets, set to module name (xxx) if not overriden with `PROVIDES yyy` directive in `define_module`.
 * Reworked module/package/target search in dependencies.