### PR TITLE
Pato/find libe57format

### DIFF
--- a/Modules.Conan/FindE57Format.cmake
+++ b/Modules.Conan/FindE57Format.cmake
@@ -1,0 +1,7 @@
+find_package(E57Format CONFIG) 
+
+if (TARGET E57Format::E57Format)
+  set(E57Format_FOUND TRUE)
+  set(E57Format_VERSION ${E57Format_VERSION})
+  set(E57Format_LIBRARIES E57Format::E57Format)
+endif()

--- a/Modules/FindE57Format.cmake
+++ b/Modules/FindE57Format.cmake
@@ -1,2 +1,2 @@
-find_package(E57Format)
+find_package(E57Format PATHS /usr/lib/cmake NO_DEFAULT_PATH)
 set(E57Format_LIBRARIES E57Format) # workaround for buildsys define_module

--- a/Modules/FindE57Format.cmake
+++ b/Modules/FindE57Format.cmake
@@ -1,0 +1,2 @@
+find_package(E57Format)
+set(E57Format_LIBRARIES E57Format) # workaround for buildsys define_module


### PR DESCRIPTION
Adds support for libE57Format library needed for reading e57 files.