### PR TITLE
[VDST-973] skip timestamp emission for .pyc files

### DIFF
--- a/tools/file2cpp/file2cpp
+++ b/tools/file2cpp/file2cpp
@@ -70,8 +70,10 @@ if version:
     hpp_file.write("    constexpr unsigned int %s_attr_version = %s;\n"
                    % (name[-1], version))
 
-hpp_file.write("    constexpr std::time_t %s_attr_lastModified(%s);\n"
-               % (name[-1], long(lastModified)))
+# skip for generated .pyc files
+if not ifile.endswith(".pyc"):
+    hpp_file.write("    constexpr std::time_t %s_attr_lastModified(%s);\n"
+                % (name[-1], long(lastModified)))
 
 for ns in reversed(name[:-1]):
     hpp_file.write("} // namespace %s\n" % (ns, ))


### PR DESCRIPTION
The files are generated on fly and will break ccache cache.